### PR TITLE
loader/service: use class name as the service name

### DIFF
--- a/lib/loader/service.js
+++ b/lib/loader/service.js
@@ -10,6 +10,7 @@ const fs = require("fs");
 const path = require("path");
 
 const _ = require("lodash");
+const Case = require("case");
 
 class Service {
     constructor(akyuu) {
@@ -33,8 +34,14 @@ class Service {
                 this.load(`${file}/${filenames[i]}`);
             } else if(_.endsWith(filenames[i], ".js")) {
                 const apiName = filenames[i].substr(0, filenames[i].length - 3).toLowerCase();
-                this.services[apiName] = new (require(`${directory}/${filenames[i]}`))();
-                this.serviceClasses[apiName] = require(`${directory}/${filenames[i]}`);
+
+                const apiClass = require(`${directory}/${filenames[i]}`);
+                const apiClassInstance = new apiClass();
+                let apiClassName = apiClassInstance.constructor.name;
+                apiClassName = Case.snake(apiClassName);
+
+                this.services[apiClassName] = apiClassInstance;
+                this.serviceClasses[apiClassName] = apiClass;
                 this.logger.info(`Service \`${apiName}\` loaded.`);
             }
         }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/akyuujs/akyuu#readme",
   "dependencies": {
     "async": "^2.1.5",
+    "case": "^1.5.2",
     "config": "^1.20.1",
     "debug": "^2.2.0",
     "ero": "^0.2.3",


### PR DESCRIPTION
Use class name as the service name when load service.

Fixes: https://github.com/akyuujs/akyuu/issues/17