### PR TITLE
config: add an env var to generate config or not

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -11,43 +11,46 @@ const path = require("path");
 
 const _ = require("lodash");
 
-const configDir = process.env.NODE_CONFIG_DIR || path.join(require.main.filename, "..", "/config");
-const currentDir = path.join(__dirname, "config");
-process.env.NODE_CONFIG_DIR = currentDir;
-
-let dirs;
-try {
-    dirs = fs.readdirSync(configDir);
-} catch(e) {
-    // ...
-}
-dirs = dirs || [];
-
 const template = fs.readFileSync(`${__dirname}/config/_template`, { encoding: "utf8" });
+const currentDir = path.join(__dirname, "config");
 
 function copy(_path, type) {
     const js = _.template(template)({ path: _path, type: type });
     fs.writeFileSync(`${__dirname}/config/${type}.js`, js, { encoding: "utf8" });
 }
 
-for(let i = 0; i < dirs.length; i++) {
-    let stat;
-    try {
-        stat = fs.statSync(path.join(configDir, dirs[i]));
-    } catch(e) {
-        stat = null;
-    }
+if(process.env.AKYUU_NO_GENERATE_CONFIG !== "true") {
+    const configDir = process.env.NODE_CONFIG_DIR || path.join(require.main.filename, "..", "/config");
 
-    if(!stat) continue;
-    if(stat.isDirectory()) {
-        copy(configDir, dirs[i]);
-    } else if(stat.isFile()) {
-        if(dirs[i].endsWith(".js")) {
-            copy(configDir, dirs[i].substr(dirs[i].length - 3));
-        } else if(dirs[i].endsWith(".json")) {
-            copy(configDir, dirs[i].substr(dirs[i].length - 5));
+    let dirs;
+    try {
+        dirs = fs.readdirSync(configDir);
+    } catch(e) {
+        // ...
+    }
+    dirs = dirs || [];
+
+    for(let i = 0; i < dirs.length; i++) {
+        let stat;
+        try {
+            stat = fs.statSync(path.join(configDir, dirs[i]));
+        } catch(e) {
+            stat = null;
+        }
+
+        if(!stat) continue;
+        if(stat.isDirectory()) {
+            copy(configDir, dirs[i]);
+        } else if(stat.isFile()) {
+            if(dirs[i].endsWith(".js")) {
+                copy(configDir, dirs[i].substr(dirs[i].length - 3));
+            } else if(dirs[i].endsWith(".json")) {
+                copy(configDir, dirs[i].substr(dirs[i].length - 5));
+            }
         }
     }
 }
+
+process.env.NODE_CONFIG_DIR = currentDir;
 
 module.exports = require("config");


### PR DESCRIPTION
If an environment variable `AKYUU_NO_GENERATE_CONFIG` is set, Akyuu.js
won't regenerate the temporary config files.

This may avoid multi-times generation of the config files for
cluster-worker mode.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
Temporarily please refer to Node.js' CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows Node.js [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core submodule(s)
<!-- Provide affected core submodule(s) (like service, model, boot, etc). -->
config