### PR TITLE
cluster, logger: support for akyuu.startCluster()

### DIFF
--- a/example/demo/src/config/default/index.js
+++ b/example/demo/src/config/default/index.js
@@ -15,6 +15,12 @@ module.exports = {
         autoStatusCode: true
     },
 
+    cluster: {
+        workerCount: 2,
+        entry: path.join(__dirname, "../../app.js"),
+        limit: 2
+    },
+
     test: {
         test1: true
     },

--- a/example/demo/src/master.js
+++ b/example/demo/src/master.js
@@ -1,0 +1,10 @@
+/**
+ * XadillaX <i@2333.moe> created at 2017-07-28 15:32:46 with ❤
+ *
+ * Copyright (c) 2017 xcoder.in, all rights reserved.
+ */
+"use strict";
+
+const akyuu = require("../../../");
+
+akyuu.startCluster();

--- a/index.js
+++ b/index.js
@@ -17,3 +17,5 @@ akyuu.Validator = require("joi");
 akyuu.Service = require("./lib/requester");
 
 module.exports = akyuu;
+
+akyuu.startCluster = require("akyuu-cluster").startCluster.bind(akyuu, __dirname);

--- a/lib/logger/index.js
+++ b/lib/logger/index.js
@@ -54,6 +54,7 @@ class Logger {
         };
 
         for(let i = 0; i < this.transportConfig.length; i++) {
+            if(this.transportConfig[i].enabled === false) continue;
             const type = _.startCase(this.transportConfig[i].type);
             const transportOption = Object.assign({}, this.transportConfig[i], {
                 timestamp: _timestamp,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "homepage": "https://github.com/akyuujs/akyuu#readme",
   "dependencies": {
+    "akyuu-cluster": "^1.0.0",
     "async": "^2.1.5",
     "case": "^1.5.2",
     "config": "^1.20.1",


### PR DESCRIPTION
Add the dependency of akyuu-cluster and make logger to adapt cluster.

Refs: https://github.com/eggjs/egg-cluster#usage

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
Temporarily please refer to Node.js' CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows Node.js [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core submodule(s)
<!-- Provide affected core submodule(s) (like service, model, boot, etc). -->
cluster, logger