### PR TITLE
service: fix logger behavior to show apiClassName

### DIFF
--- a/lib/loader/service.js
+++ b/lib/loader/service.js
@@ -33,8 +33,6 @@ class Service {
             if(stat.isDirectory()) {
                 this.load(`${file}/${filenames[i]}`);
             } else if(_.endsWith(filenames[i], ".js")) {
-                const apiName = filenames[i].substr(0, filenames[i].length - 3).toLowerCase();
-
                 const ApiClass = require(`${directory}/${filenames[i]}`);
                 const apiClassInstance = new ApiClass();
                 let apiClassName = apiClassInstance.constructor.name;
@@ -42,7 +40,7 @@ class Service {
 
                 this.services[apiClassName] = apiClassInstance;
                 this.serviceClasses[apiClassName] = ApiClass;
-                this.logger.info(`Service \`${apiName}\` loaded.`);
+                this.logger.info(`Service \`${apiClassName}\` loaded.`);
             }
         }
     }


### PR DESCRIPTION
When print error message, logger should print `apiClassName` instead of
`apiName`.

Fixes: https://github.com/akyuujs/akyuu/issues/23

##### Checklist

- [x] commit message follows Node.js [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core submodule(s)

service