### PR TITLE
akyuu: move `init()` to constructor

### DIFF
--- a/example/demo/src/app.js
+++ b/example/demo/src/app.js
@@ -6,9 +6,12 @@
  */
 "use strict";
 
+const path = require("path");
+
 const akyuu = require("../../../");
 
-akyuu.init(err => {
+akyuu.setTemplateRoot(path.resolve(__dirname, "templates"));
+akyuu.init(function(err) {
     if(err) {
         console.error("Failed to start akyuu.js");
         console.error(err.stack);

--- a/lib/akyuu.js
+++ b/lib/akyuu.js
@@ -47,11 +47,12 @@ class Akyuu extends Express {
         this.controller = new Controller(this);
         this.service = new Service(this);
         this.boot = new Boot(this);
+
+        super.init();
     }
 
     init(callback) {
         const self = this;
-        super.init();
 
         // load logger
         this.logger.load();


### PR DESCRIPTION
Fixes: https://github.com/akyuujs/akyuu/issues/37

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/nodejs/node/blob/master/CONTRIBUTING.md
Temporarily please refer to Node.js' CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] commit message follows Node.js [commit guidelines](https://github.com/nodejs/node/blob/master/CONTRIBUTING.md#commit-message-guidelines)

##### Affected core submodule(s)
<!-- Provide affected core submodule(s) (like service, model, boot, etc). -->
express