### PR TITLE
v0.5.1 proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,26 @@
 </tr>
 <tr>
 <td>
+<a href="#0.5.1">0.5.1</a><br />
 <a href="#0.5.0">0.5.0</a><br />
 <a href="#0.4.0">0.4.0</a><br />
 <a href="#0.3.0">0.3.0</a><br />
 </td>
 </tr>
 </table>
+
+<a id="0.5.1"></a>
+## 2018-03-02, Version 0.5.1 (Current), @DuanPengfei
+
+### Notable changes
+
+* **Core**
+  * Fix can't set template root and engine before `init()`.
+
+### Commits
+
+* [[`146512f75e`]](https://github.com/akyuujs/akyuu/commit/146512f75e308691d3db1475e6a11ef4080bb549) - akyuu: move `init()` to constructor (@XadillaX) [#38](https://github.com/akyuujs/akyuu/pull/38)
+
 
 <a id="0.5.0"></a>
 ## 2017-10-23, Version 0.5.0 (Current), @DuanPengfei

--- a/example/demo/src/app.js
+++ b/example/demo/src/app.js
@@ -6,9 +6,12 @@
  */
 "use strict";
 
+const path = require("path");
+
 const akyuu = require("../../../");
 
-akyuu.init(err => {
+akyuu.setTemplateRoot(path.resolve(__dirname, "templates"));
+akyuu.init(function(err) {
     if(err) {
         console.error("Failed to start akyuu.js");
         console.error(err.stack);

--- a/lib/akyuu.js
+++ b/lib/akyuu.js
@@ -47,11 +47,12 @@ class Akyuu extends Express {
         this.controller = new Controller(this);
         this.service = new Service(this);
         this.boot = new Boot(this);
+
+        super.init();
     }
 
     init(callback) {
         const self = this;
-        super.init();
 
         // load logger
         this.logger.load();


### PR DESCRIPTION
## 2018-03-02, Version 0.5.1 (Current), @DuanPengfei

### Notable changes

* **Core**
  * Fix can't set template root and engine before `init()`.

### Commits

* [[`146512f75e`]](https://github.com/akyuujs/akyuu/commit/146512f75e308691d3db1475e6a11ef4080bb549) - akyuu: move `init()` to constructor (@XadillaX) [#38](https://github.com/akyuujs/akyuu/pull/38)